### PR TITLE
feat: unify write API responses

### DIFF
--- a/api_write_user/app.ts
+++ b/api_write_user/app.ts
@@ -5,43 +5,38 @@ import express from 'express';
 import { client } from './mongodb-init';
 import { createUser, updateUser, deleteUser } from './src/controllers/userController';
 import { User, UserCreate, UserFilter } from './src/interfaces/user.interface';
+import handle from './src/shared/response-handler';
 
 const port = 3001;
 const app = express();
 app.use(express.json());
 
-app.post('/user', async (req,res) => {
-  const request = req.body as UserCreate;
-  const result = await createUser(request);
-  res.send({
-    response: result
-  });
-});
+app.post(
+  '/user',
+  handle(async (req) => {
+    const request = req.body as UserCreate;
+    return await createUser(request);
+  })
+);
 
 // Update user by id
-app.put('/users/:id', async (req,res) => {
-  try {
+app.put(
+  '/users/:id',
+  handle(async (req) => {
     const { id } = req.params;
     const payload = req.body as Partial<User>;
-
-    // The controller expects a full User shape; cast for now
-    const result = await updateUser(id, payload as User);
-    res.send({ response: result });
-  } catch (err: any) {
-    res.status(500).send({ error: err?.message ?? 'Unexpected error' });
-  }
-});
+    return await updateUser(id, payload as User);
+  })
+);
 
 // Delete user by id
-app.delete('/users/:id', async (req,res) => {
-  try {
+app.delete(
+  '/users/:id',
+  handle(async (req) => {
     const { id } = req.params;
-    const result = await deleteUser(id);
-    res.send({ response: result });
-  } catch (err: any) {
-    res.status(500).send({ error: err?.message ?? 'Unexpected error' });
-  }
-});
+    return await deleteUser(id);
+  })
+);
 
 app.listen(port, async () => {
   try {    

--- a/api_write_user/src/shared/response-handler.ts
+++ b/api_write_user/src/shared/response-handler.ts
@@ -1,0 +1,28 @@
+import { Request, Response } from 'express';
+
+/**
+ * Wraps an async route handler to provide uniform response payloads
+ * and capture request latency.
+ *
+ * The returned handler automatically measures the time it takes to
+ * execute the provided function and attaches that latency (in
+ * milliseconds) to the response. On success, the payload is returned
+ * under the `data` property; on failure, the error message is exposed
+ * under the `error` property while `data` is set to `null`.
+ */
+export const handle = <T>(fn: (req: Request) => Promise<T>) => {
+  return async (req: Request, res: Response): Promise<void> => {
+    const start = process.hrtime.bigint();
+
+    try {
+      const data = await fn(req);
+      const latency = Number(process.hrtime.bigint() - start) / 1_000_000;
+      res.send({ data, latency, error: null });
+    } catch (err: any) {
+      const latency = Number(process.hrtime.bigint() - start) / 1_000_000;
+      res.status(500).send({ data: null, latency, error: err?.message ?? 'Unexpected error' });
+    }
+  };
+};
+
+export default handle;


### PR DESCRIPTION
## Summary
- add response handler middleware for consistent responses and latency
- update write API routes to use unified payloads

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1410c8e44832bb6310d275ffc224f